### PR TITLE
audio output fails when default_input_config() on output device [Windows]

### DIFF
--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -172,11 +172,12 @@ async fn get_device_and_config(
     }
     .ok_or_else(|| anyhow!("Audio device not found"))?;
 
-    let mut config = audio_device.default_input_config()?;
     // if output device and windows, using output config
-    if cfg!(target_os = "windows") && is_output_device {
-        config = audio_device.default_output_config()?;
-    }
+    let config = if is_output_device && cfg!(target_os = "windows") {
+        audio_device.default_output_config()?
+    } else {
+        audio_device.default_input_config()?
+    };
     Ok((audio_device, config))
 }
 


### PR DESCRIPTION
[Issue 127](https://github.com/louis030195/screen-pipe/issues/127)

- When default_input_config() was called on a output device, the tread paniced.

How to previously product the bug:
```
build the project
screenpipe --list-audio-devices
screenpipe --audio-device "myaudio device"
```
After the changes, made a build and tested the above, it run properly without the panic and error. Also, the correct audio is being stored properly of 30 seconds. Tried recording a few things and it was working.

Also, I think we there is no need to make the config `mutable` anymore. [Let me know if there is something which could break due to this]

/claim #127